### PR TITLE
Upgrade to PostgreSQL 9.5.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.5.8
+FROM postgres:9.5.13
 
 RUN apt-get update \
   && apt-get upgrade --no-install-recommends -y \


### PR DESCRIPTION
This is a newer image built on top of Debian stretch. The `postgres:9.5.8` image is built on jessie which is past its EOL date.