### PR TITLE
[CIRCLE-27771] Bump base Postgres and CCC images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
   deploy:
     docker:
-      - image: circleci/command-convenience:0.1.811-e320c67
+      - image: circleci/command-convenience:0.1
         auth:
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASSWORD

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.5.16
+FROM postgres:9.5.23
 
 RUN apt-get update \
   && apt-get upgrade --no-install-recommends -y \


### PR DESCRIPTION
* We take the latest CCC 0.1 rather than pinning it, as is normal in our services now.
* Take the latest 9.5.x postgres image (built 24 days ago): https://hub.docker.com/layers/postgres/library/postgres/9.5.23/images/sha256-fd416f540226c0034dcc41076630dca7fc59b27f44cc36d1970be6829fb852ed