### PR TITLE
[CIRCLE-30777] Bump Postgres image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.5.23
+FROM postgres:9.5.24
 
 RUN apt-get update \
   && apt-get upgrade --no-install-recommends -y \


### PR DESCRIPTION
- Take the latest 9.5.x postgres image (built 12 days ago): https://hub.docker.com/layers/postgres/library/postgres/9.5.24/images/sha256-776c16c645b8464c865e620f50c89c26c9db19c54fff463c6dffd09728ae4b32?context=explore

Following similar work we did for a [previous patch](https://github.com/circleci/postgres-docker/pull/6) 