### PR TITLE
SERVER-1555 | Revert to 9.5.25 from 12.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:12
+FROM postgres:9.5.25
 
 RUN apt-get update \
   && apt-get upgrade --no-install-recommends -y \


### PR DESCRIPTION
Server 2 can't use postgres 12. It must use 9.5