### PR TITLE
Publish image on server 2.19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,18 +15,16 @@ jobs:
     working_directory: /home/circleci/postgres
 
     steps:
-      - checkout
-
-      - setup_remote_docker
-
-      - run: publish
+    - checkout
+    - setup_remote_docker
+    - run: publish
 
 workflows:
   version: 2
   deploy:
     jobs:
-      - deploy:
-          context: org-global
-          filters:
-            branches:
-              only: master
+    - deploy:
+        context: org-global
+        filters:
+          branches:
+            only: server-2.19


### PR DESCRIPTION
Now that `server-2.19` is the default branch, change CI to publish the docker image on commits to that branch